### PR TITLE
Chef 13 Deprecation Fix

### DIFF
--- a/lib/poise_archive/archive_providers/zip.rb
+++ b/lib/poise_archive/archive_providers/zip.rb
@@ -44,7 +44,9 @@ module PoiseArchive
       end
 
       def install_rubyzip
-        chef_gem 'rubyzip'
+        chef_gem 'rubyzip' do
+          compile_time true
+        end
       end
 
       def unpack_zip


### PR DESCRIPTION
I am using poise archive in another cookbook and recently turned on deprecations as errors in my Chef 12 environment. I get the following:

```
          * directory[/opt/consul/0.9.3] action create[2017-10-23T18:42:33+00:00] INFO: Processing directory[/opt/consul/0.9.3] action create (/tmp/kitchen/cache/cookbooks/poise-arch
ive/files/halite_gem/poise_archive/archive_providers/base.rb line 100)
        (up to date)
       [2017-10-23T18:42:33+00:00] ERROR: chef_gem[rubyzip] chef_gem compile_time installation is deprecated. Please set `compile_time false` on the resource to use the new behavior, or
 set `compile_time true` on the resource if compile_time behavior is required. (CHEF-3)/tmp/kitchen/cache/cookbooks/poise-archive/files/halite_gem/poise_archive/archive_providers/zip.rb
:47:in `install_rubyzip'.
       Please see https://docs.chef.io/deprecations_chef_gem_compile_time.html for further details and information on how to correct this problem. at /opt/chef/embedded/lib/ruby/gems/2.
3.0/gems/chef-12.21.20/lib/chef/formatters/doc.rb:419:in `deprecation'
```

I believe this is tracked back to the `chef_gem rubyzip` resource which I have updated.